### PR TITLE
Turning `Map` into an interface & a template. Derived classes of `Tile` & `Unit` with sprite information

### DIFF
--- a/oe-raylib/source/spriteSet.d
+++ b/oe-raylib/source/spriteSet.d
@@ -3,7 +3,7 @@ import std.string : toStringz;
 import raylib;
 import unit;
 
-class UnitSpriteLibrary
+class UnitSpriteSet
 {
     Image[8][4] attack_spear;
     Image[8][4] attack_bow;

--- a/oe-raylib/source/vector_math.d
+++ b/oe-raylib/source/vector_math.d
@@ -1,4 +1,5 @@
 import raylib;
+import common;
 
 Vector2 rectDest(Rectangle rect, Vector2 offset, bool otherCorner = false) { //Determines where to place a rectangle by adding it's built-in x and y values to an offset.
     Vector2 location = offset;
@@ -9,10 +10,4 @@ Vector2 rectDest(Rectangle rect, Vector2 offset, bool otherCorner = false) { //D
         location.y += rect.height;
     }
     return location;
-}
-
-struct Vector2i
-{
-    int x;
-    int y;
 }

--- a/oe-raylib/source/vtile.d
+++ b/oe-raylib/source/vtile.d
@@ -27,8 +27,6 @@ class VisibleTile : Tile//T!VisibleTile
         this.rect.y = cast(float) y * TILEHEIGHT;
         this.rect.width = TILEWIDTH;
         this.rect.height = TILEHEIGHT;
-        
-        if (textureName in spriteIndex) this.sprite = spriteIndex[textureName];
 
         super();
     }

--- a/oe-raylib/source/vtile.d
+++ b/oe-raylib/source/vtile.d
@@ -40,4 +40,11 @@ class VisibleTile : Tile//T!VisibleTile
     Rectangle getRect() {
         return this.rect;
     }
+
+    Rectangle getRect(Vector2 offset) {
+        Rectangle rect = this.rect;
+        rect.x += offset.x;
+        rect.y += offset.y;
+        return rect;
+    }
 }

--- a/oe-raylib/source/vtile.d
+++ b/oe-raylib/source/vtile.d
@@ -1,0 +1,45 @@
+import std.json;
+import raylib;
+import tile;
+import common;
+
+const uint TILEWIDTH = 64;
+const uint TILEHEIGHT = 64;
+
+class VisibleTile : Tile//T!VisibleTile
+{
+    Texture2D* sprite;
+    Rectangle rect;
+    Vector2i origin;
+
+    this(JSONValue tileData, ref Texture*[string] spriteIndex, uint x, uint y) {
+        string tileName = "";
+        if ("name" in tileData) tileName = tileData["name"].get!string;
+        this.allowStand = tileData["canWalk"].get!bool;
+        if ("canFly" in tileData) this.allowFly = tileData["canFly"].get!bool;
+        this.stickyness = tileData["stickiness"].get!int;
+        this.textureName = tileData["tile_sprite"].get!string;
+        this.xlocation = cast(short) x;
+        this.ylocation = cast(short) y;
+        this.origin.x = cast(int) x * TILEWIDTH;
+        this.origin.x = cast(int) y * TILEHEIGHT;
+        this.rect.x = cast(float) x * TILEWIDTH;
+        this.rect.y = cast(float) y * TILEHEIGHT;
+        this.rect.width = TILEWIDTH;
+        this.rect.height = TILEHEIGHT;
+        
+        if (textureName in spriteIndex) this.sprite = spriteIndex[textureName];
+
+        super();
+    }
+
+    Vector2 getDestination (Vector2 offset) {
+        offset.x += this.origin.x;
+        offset.y += this.origin.y;
+        return offset;
+    }
+
+    Rectangle getRect() {
+        return this.rect;
+    }
+}

--- a/oe-raylib/source/vunit.d
+++ b/oe-raylib/source/vunit.d
@@ -1,0 +1,31 @@
+import std.json;
+import raylib;
+import unit;
+import spriteSet;
+import mission;
+
+class VisibleUnit : Unit
+{
+    //UnitSpriteSet spriteSet;
+    Texture2D sprite;
+
+    this(Mission map, JSONValue unitData) {
+        import std.string:toStringz;
+        import std.path : buildNormalizedPath;
+        import std.algorithm.searching;
+        import std.stdio;
+
+        super(map, unitData);
+        string spritePath = ("../sprites/units/" ~ unitData["Sprite"].get!string); //.buildNormalizedPath;
+        if (!spritePath.endsWith(".png")) spritePath ~= ".png";
+        writeln("Sprite for unit "~this.name~" is "~spritePath);
+        this.sprite = LoadTexture(spritePath.toStringz);
+    }
+
+    void verify() {
+        assert(this.currentTile !is null, "Unit "~name~"'s `currentTile` property is not set.");
+        assert(this.currentTile.occupant == this, "Unit "~name~" has it's `currentTile` property set to a Tile object, but that Tile object does not have "~name~" in it's `occupant` property.");
+        assert(this.xlocation == this.currentTile.x, "Unit "~name~"'s `xlocation` property is not the same as it's tile's.");
+        assert(this.ylocation == this.currentTile.y, "Unit "~name~"'s `ylocation` property is not the same as it's tile's.");
+    }
+}

--- a/source/common.d
+++ b/source/common.d
@@ -1,0 +1,6 @@
+
+struct Vector2i //If being used with Godot-Dlang, may interfere with the struct of the same name.
+{
+    int x;
+    int y;
+}

--- a/source/map.d
+++ b/source/map.d
@@ -6,7 +6,7 @@ import std.json;
 import tile;
 import unit;
 
-class MapTemp (TileType : Tile) : Map {
+class MapTemp (TileType:Tile, UnitType:Unit) : Map {
     public string name;
     
     protected TileType[][] grid;
@@ -18,8 +18,8 @@ class MapTemp (TileType : Tile) : Map {
     public int turn;
 
     public Faction[] factions;
-    public Unit[] allUnits;
-    public Unit[][string] factionUnits;
+    public UnitType[] allUnits;
+    public UnitType[][string] factionUnits;
 
     this(string name) {
         this.name = name;
@@ -78,14 +78,16 @@ class MapTemp (TileType : Tile) : Map {
                     faction.isPlayer = false;
                 }
                 this.factionUnits[faction.name] = [];
-                faction.units = &this.factionUnits[faction.name];
+                if (this.fullyLoaded) foreach (unit; this.factionUnits[faction.name]) {
+                    faction.units ~= cast(Unit) unit;
+                }
                 this.factions ~= faction;
             }
             return true;
         } else {
             this.factions ~= Faction(name: "enemy");
             this.factionUnits["enemy"] = [];
-            this.factions[$-1].units = &this.factionUnits["enemy"];
+            foreach (unit; this.factionUnits["enemy"]) this.factions[$-1].units ~= cast(Unit) unit;
             return false;
         }
     }
@@ -203,7 +205,7 @@ enum GamePhase : ubyte {
 struct Faction
 {
     string name;
-    Unit[]* units;
+    Unit[] units;
     string[] allies;
     bool isPlayer;
 }

--- a/source/map.d
+++ b/source/map.d
@@ -6,9 +6,7 @@ import std.json;
 import tile;
 import unit;
 
-alias TileType = Tile;
-
-class Map {
+class MapTemp (TileType : Tile) : Map {
     public string name;
     
     protected TileType[][] grid;
@@ -27,17 +25,17 @@ class Map {
         this.name = name;
     }
     
-    this(ushort width, ushort length) {
+    /*this(ushort width, ushort length) {
         this.grid.length = width;
         foreach (x; 0 .. width-1) {
             this.grid[x].length = length;
             foreach (y; 0 .. length-1) {
-                this.grid[x][y] = new Tile();
+                this.grid[x][y] = new TileType();
             }
         }
-    this.gridWidth = width;
-    this.gridLength = length;
-    this.fullyLoaded = true;
+        this.gridWidth = width;
+        this.gridLength = length;
+        this.fullyLoaded = true;
     }
 
     this(JSONValue mapData) {
@@ -60,11 +58,11 @@ class Map {
                 int stickiness = tile["stickiness"].get!int;
                 string textureName = tile["tile_sprite"].get!string;
                 ushort textureID = this.findAssignTextureID(textureName);
-                this.grid[x][y] = new Tile(tileName, allowStand, allowFly, stickiness, textureID, textureName);
+                this.grid[x][y] = new TileType(tileName, allowStand, allowFly, stickiness, textureID, textureName);
             }
         }
         this.fullyLoaded = true;
-    }
+    }*/
 
     protected bool loadFactionsFromJSON (JSONValue mapData) {
         this.factions ~= Faction(name:"Player");
@@ -132,18 +130,30 @@ class Map {
     }
 
     Tile[][] getGrid() {
-        return this.grid;
+        Tile[][] tileGrid;
+        tileGrid.length = this.grid.length;
+        foreach(int x, row; this.grid) {
+            foreach(tile; row) {
+                tileGrid[x] ~= tile;
+            }
+        }
+        
+        return tileGrid;
+    }
+
+    bool allTilesLoaded() {
+        return this.fullyLoaded;
     }
 
     Unit getOccupant(int x, int y) {
         return this.grid[x][y].occupant;
     }
     
-    ushort getWidth() {
-        return cast(ushort)this.grid.length;
+    uint getWidth() {
+        return cast(uint)this.grid.length;
     }
-    ushort getLength() {
-        return cast(ushort)this.grid[0].length;
+    uint getLength() {
+        return cast(uint)this.grid[0].length;
     }
 
     string[] getTextureIndex() {
@@ -159,6 +169,15 @@ class Map {
         this.textureIndex ~= textureName;
         return cast(ushort)(this.textureIndex.length - 1);
     }
+}
+
+interface Map {
+    Tile getTile(int x, int y);
+    Tile[][] getGrid();
+    uint getWidth();
+    uint getLength();
+    Unit getOccupant(int x, int y);
+    bool allTilesLoaded();
 }
 
 ushort findAssignTextureID (string[] textureIndex, string textureName) {

--- a/source/tile.d
+++ b/source/tile.d
@@ -9,8 +9,8 @@ class Tile
 	protected bool allowFly = true;
 	public int stickyness = 0;
 
-	short xlocation;
-	short ylocation;
+	protected short xlocation;
+	protected short ylocation;
 
 	public bool startLocation = false;
 
@@ -36,5 +36,12 @@ class Tile
 	bool allowUnit(bool isFlyer) {
 		if (isFlyer) return this.allowFly;
 		else return this.allowStand;
+	}
+
+	int x() {
+		return cast(int) this.x;
+	}
+	int y() {
+		return cast(int) this.y;
 	}
 }

--- a/source/tile.d
+++ b/source/tile.d
@@ -39,9 +39,9 @@ class Tile
 	}
 
 	int x() {
-		return cast(int) this.x;
+		return cast(int) this.xlocation;
 	}
 	int y() {
-		return cast(int) this.y;
+		return cast(int) this.ylocation;
 	}
 }

--- a/source/tile.d
+++ b/source/tile.d
@@ -5,9 +5,12 @@ import unit;
 class Tile
 {
 	public string tileName;
-	private bool allowStand = true;
-	private bool allowFly = true;
+	protected bool allowStand = true;
+	protected bool allowFly = true;
 	public int stickyness = 0;
+
+	short xlocation;
+	short ylocation;
 
 	public bool startLocation = false;
 

--- a/source/unit.d
+++ b/source/unit.d
@@ -4,6 +4,7 @@ import std.stdio;
 import std.conv;
 import std.json;
 
+import common;
 import map;
 import tile;
 import item;
@@ -31,6 +32,7 @@ class Unit {
     public Weapon* currentWeapon;
     private TileAccess[][] distances;
     private uint MvRemaining;
+    alias moveRemaining = MvRemaining;
     public bool hasActed;
     public int HP;
 
@@ -139,8 +141,15 @@ class Unit {
         writeln(this.map.getTile(x,y));
         this.map.getTile(x, y).setOccupant(this);
         
-        if (this.map.fullyLoaded) this.updateDistances(0);
-        write("Finished Unit.setLocation.");
+        if (runUpdateDistances && this.map.allTilesLoaded()) this.updateDistances(0);
+    }
+
+    bool move (int x, int y) {
+        if (this.distances[x][y].reachable) {
+            this.moveRemaining -= this.distances[x][y].distance;
+            this.setLocation(x, y, true);
+            return true;
+        } else return false;
     }
 
     bool attack (uint x, uint y) {
@@ -205,6 +214,16 @@ class Unit {
 
     TileAccess getDistance(int x, int y) {
         return this.distances[x][y];
+    }
+
+    Vector2i[] getReachable() {
+        Vector2i[] reachableCoordinates;
+        foreach (int x, row; this.distances) {
+            foreach (int y, tileAccess; row) {
+                reachableCoordinates ~= Vector2i(x, y);
+            }
+        }
+        return reachableCoordinates;
     }
 
     UnitStats getStats() {

--- a/source/unit.d
+++ b/source/unit.d
@@ -100,7 +100,7 @@ class Unit {
         this.Def = unitData.object["Def"].get!uint;
 
         if ("Weapon" in unitData.object) {
-            Weapon weapon = new Weapon(unitData.object["Weapon"]);
+            Weapon weapon = new Weapon(unitData.object["Weapon"]); //Come back here later to uncomment when the memory error is resolved.
             this.currentWeapon = &weapon;
             //this.inventory[0] = &weapon;
         }


### PR DESCRIPTION
This branch changes the way that graphical information (sprites & Raylib Rectangles) for Tiles and Units are kept. Currently in the main branch, the `Tile` and `Unit` class both have a `textureID` or `spriteID` property as an integer. The `Mission` class holds an array of Raylib textures (`struct Texture2D`), and assigns the values of `textureID` and `spriteID` to the array key for their appropriate texture. A struct called `GridTile` specific to the Raylib frontend also holds a Raylib `Rectangle` instance for each `Tile` object. The central library contains nothing specific to Raylib so that it can be reused for other front-ends without unnecessary code.

This new version keeps the main library disconnected from any graphical library, but it changes how things work. Now the `Map` class has been turned into an interface called `Map` and a template called `MapTemp`. The template allows `Tile` and `Unit` to be replaced with derived types.

Taking advantage of this new feature, the Raylib front-end in this branch now has a derived class of `Tile` called `VisibleTile` which holds a pointer to a raylib texture, and a derived class of `Unit` called `VisibleUnit` which holds it's own texture, soon to be replaced by a `SpriteSet` object.

This change simplifies the code in the Raylib front-end because less trickery is needed to associate Tile & Unit objects with sprites. The main library is now slightly more complex, but much more adaptable.

I haven't yet benchmarked the version in `master` for comparison, but in this one I got over 4000 frames per-second on my years-old desktop.